### PR TITLE
update conda channel for vmd-python

### DIFF
--- a/getting_started.html
+++ b/getting_started.html
@@ -97,7 +97,7 @@
   pip install ticc==0.1.4
   
   # Set up vmd-python library
-  conda install -c https://conda.anaconda.org/rbetz vmd-python
+  conda install -c conda-forge vmd-python
   
   # Set up getcontacts library
   git clone https://github.com/getcontacts/getcontacts.git


### PR DESCRIPTION
Dear mantainers, 
I tried to install `vmd-python` following your [Getting Started](https://getcontacts.github.io/getting_started.html) page, but I encountered this error:
```bash
PackagesNotFoundError: The following packages are not available from current channels:
                                                                                
    - vmd-python       
```
It looks like the `vmd-python` package has been moved into `conda-forge`, see [VMD-python](https://vmd.robinbetz.com/). 
Therefore I propose the following change.

Thank you for your time.